### PR TITLE
make AST a separate package, move file

### DIFF
--- a/src/main/scala/miniJavaParser/AST.scala
+++ b/src/main/scala/miniJavaParser/AST.scala
@@ -1,4 +1,4 @@
-package miniJavaParser
+package miniJavaParser.AST
 
 // Top-Level Trait für alle AST-Knoten
 sealed trait ASTNode

--- a/src/main/scala/miniJavaParser/bytecodegen.scala
+++ b/src/main/scala/miniJavaParser/bytecodegen.scala
@@ -1,13 +1,14 @@
 package miniJavaParser
+import AST.*
 
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes.*
-import _root_.miniJavaParser.Modifier.Public
-import _root_.miniJavaParser.Modifier.Abstract
-import _root_.miniJavaParser.Modifier.Final
-import _root_.miniJavaParser.Modifier.Private
-import _root_.miniJavaParser.Modifier.Protected
-import _root_.miniJavaParser.Modifier.Static
+import Modifier.Public
+import Modifier.Abstract
+import Modifier.Final
+import Modifier.Private
+import Modifier.Protected
+import Modifier.Static
 
 def codeGen(comp: CompilationUnit): Array[Byte] = {
     comp.typeDeclarations.find(x => x match {

--- a/src/main/scala/miniJavaParser/parser.scala
+++ b/src/main/scala/miniJavaParser/parser.scala
@@ -1,4 +1,5 @@
 package miniJavaParser
+import AST.*
 
 import org.antlr.v4.runtime.{CharStreams, CommonTokenStream, ParserRuleContext}
 


### PR DESCRIPTION
Ich würde den Typencheck in einem separaten `package` aufbauen, wenn man den AST vom Rest trennt, werden die Importe schöner.